### PR TITLE
Remove Default Bound on vec::Transformable #17

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -193,7 +193,7 @@ impl<'a,T:Tokeniser> IntoIterator for &'a Tokenisation<T> {
 /// Allow a tokenisation to be incrementally updated through a
 /// _transformation_ on the underlying sequence.
 impl<T:Tokeniser> PartiallyTransformable for Tokenisation<T>
-where T::Input: Clone + Default {
+where T::Input: Clone {
     /// A tokenisation delta corresponds to a delta on the underlying
     /// input sequence.  They key is that applying this delta to the
     /// tokenisation requires that it _incrementally updates_ the

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -44,14 +44,14 @@ impl<T> Delta<T> {
 pub fn insert<T>(index: usize, data: Vec<T>) -> Delta<T> {
     let rw = Rewrite::new(Region::new(index,0),data);
     Delta{rewrites: vec![rw]}
-}    
+}
 
 /// Construct a delta which replaces a given range of elements with
 /// another sequence of zero or more items.
 pub fn replace<T>(range: Range<usize>, data: Vec<T>) -> Delta<T> {
     let rw = Rewrite::new(range.into(),data);
     Delta{rewrites: vec![rw]}
-}    
+}
 
 /// Construct a delta which removes one or more elements from the
 /// vector.
@@ -64,9 +64,9 @@ pub fn remove<T>(range: Range<usize>) -> Delta<T> {
 // Transformable
 // ===================================================================
 
-impl<T:Default + std::clone::Clone> Transformable for Vec<T> {
+impl<T:std::clone::Clone> Transformable for Vec<T> {
     type Delta = Delta<T>;
-    
+
     fn transform(&mut self,d: &Self::Delta) {
 	// NOTE: this is a very inefficient implementation which I
 	// have written as scafolding to get this library up and
@@ -77,4 +77,3 @@ impl<T:Default + std::clone::Clone> Transformable for Vec<T> {
 	}
     }
 }
-


### PR DESCRIPTION
This removes the `Default` bound for `T` in `Transformable` on `Vec<T>`.