### PR TITLE
Add Delta::iter() #19

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -206,6 +206,14 @@ where T::Input: Clone {
     fn transform(&mut self,d: &Self::Delta) -> Result<(),Self::Error> {
         // Transform the underlying items.
         self.items.transform(d);
+        // Construct starts delta
+        // FIXME: this is not efficient.
+        let rws : Vec<vec::Rewrite<bool>> = d.iter().map(|r| r.map(|i| false)).collect();
+        let sd : vec::Delta<bool> = vec::Delta::from(rws);
+        // Apply starts delta
+        self.starts.transform(&sd);
+        // Sanity check.
+        assert!(self.starts.len() == self.items.len());
         // Transform starts
         self.starts = Self::generate_starts(&self.items,&self.tokeniser)?;
         // All good!

--- a/src/region.rs
+++ b/src/region.rs
@@ -2,7 +2,7 @@ use std::cmp::{PartialOrd,Ordering};
 use std::convert::From;
 use std::ops::Range;
 
-#[derive(PartialEq,Debug)]
+#[derive(Copy,Clone,Debug,PartialEq)]
 pub struct Region {
     /// Starting point in source hunk of this rewrite.
     pub offset: usize,


### PR DESCRIPTION
This adds the ability to iterate over the rewrites contained within a
Delta.  Furthermore, we can map a rewrite from one type to another as
well.  So, for example, we can take a delta over integers and construct
a "mirror" delta over booleans.  This is quite useful for managing the
updates of meta-data.  However, its not clear that its actually useful
long term.